### PR TITLE
Add support for Windows (and some other changes)

### DIFF
--- a/datetime_tz/update_win32tz_map.py
+++ b/datetime_tz/update_win32tz_map.py
@@ -1,0 +1,57 @@
+import os
+import urllib2
+import StringIO
+import genshi.input
+import hashlib
+import win32tz_map
+
+def download_cldr_win32tz_map_xml():
+    """Downloads the xml that maps between Windows and Olson timezone names"""
+    return urllib2.urlopen("http://www.unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml").read()
+
+def create_win32tz_map(windows_zones_xml):
+    """Creates a map between Windows and Olson timezone names based on the cldr xml mapping. Yields win32_name, olson_name, comment tuples"""
+    just_closed = None
+    parser = genshi.input.XMLParser(StringIO.StringIO(windows_zones_xml))
+    map_zones = {}
+    zone_comments = {}
+    for kind, data, pos in parser:
+        if kind == genshi.core.START and str(data[0]) == 'mapZone':
+            attrs = data[1]
+            win32_name, olson_name = attrs.get("other"), attrs.get("type")
+            map_zones[win32_name] = olson_name
+        elif kind == genshi.core.END and str(data) == 'mapZone':
+            just_closed = win32_name
+        elif kind == genshi.core.COMMENT and just_closed:
+            zone_comments[just_closed] = data.strip()
+        elif kind in (genshi.core.START, genshi.core.END, genshi.core.COMMENT):
+            just_closed = None
+    for win32_name in sorted(map_zones):
+        yield (win32_name, map_zones[win32_name], zone_comments.get(win32_name, None))
+
+def update_stored_win32tz_map():
+    """downloads the cldr win32 timezone map and stores it in win32tz_map.py"""
+    windows_zones_xml = download_cldr_win32tz_map_xml()
+    source_hash = hashlib.md5(windows_zones_xml).hexdigest()
+    map_zones = create_win32tz_map(windows_zones_xml)
+    map_dir = os.path.dirname(os.path.abspath(__file__))
+    map_filename = os.path.join(map_dir, "win32tz_map.py")
+    reload(win32tz_map)
+    current_hash = getattr(win32tz_map, "source_hash", None)
+    if current_hash == source_hash:
+        return False
+    map_file = open(map_filename, "w")
+    comment = "Map between Windows an Olson timezones taken from http://www.unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml"
+    comment2 = "Generated automatically from datetime_tz.py"
+    map_file.write("'''%s\n" % comment)
+    map_file.write("%s'''\n" % comment2)
+    map_file.write("source_hash = '%s' # md5 sum of xml source data\n" % (source_hash))
+    map_file.write("win32timezones = {\n")
+    for win32_name, olson_name, comment in map_zones:
+        map_file.write("    %r: %r, # %s\n" % (win32_name, olson_name, comment or ''))
+    map_file.write("}\n")
+    map_file.close()
+    return True
+
+if __name__ == '__main__':
+    update_stored_win32tz_map()

--- a/datetime_tz/win32tz_map.py
+++ b/datetime_tz/win32tz_map.py
@@ -1,0 +1,101 @@
+'''Map between Windows an Olson timezones taken from http://www.unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml
+Generated automatically from datetime_tz.py'''
+source_hash = '219ad1cf41309618a241ccf36a6b7ef1' # md5 sum of xml source data
+win32timezones = {
+    u'AUS Central Standard Time': u'Australia/Darwin', # S (GMT+09:30) Darwin
+    u'AUS Eastern Standard Time': u'Australia/Sydney', # D (GMT+10:00) Canberra, Melbourne, Sydney
+    u'Afghanistan Standard Time': u'Asia/Kabul', # S (GMT+04:30) Kabul
+    u'Alaskan Standard Time': u'America/Anchorage', # D (GMT-09:00) Alaska
+    u'Arab Standard Time': u'Asia/Riyadh', # S (GMT+03:00) Kuwait, Riyadh
+    u'Arabian Standard Time': u'Asia/Dubai', # S (GMT+04:00) Abu Dhabi, Muscat
+    u'Arabic Standard Time': u'Asia/Baghdad', # S (GMT+03:00) Baghdad
+    u'Argentina Standard Time': u'America/Buenos_Aires', # D (GMT-03:00) Buenos Aires
+    u'Armenian Standard Time': u'Asia/Yerevan', # D [XP] (GMT+04:00) Yerevan
+    u'Atlantic Standard Time': u'America/Halifax', # D (GMT-04:00) Atlantic Time (Canada)
+    u'Azerbaijan Standard Time': u'Asia/Baku', # D (GMT+04:00) Baku
+    u'Azores Standard Time': u'Atlantic/Azores', # D (GMT-01:00) Azores
+    u'Bangladesh Standard Time': u'Asia/Dhaka', # D (GMT+06:00) Dhaka
+    u'Canada Central Standard Time': u'America/Regina', # S (GMT-06:00) Saskatchewan
+    u'Cape Verde Standard Time': u'Atlantic/Cape_Verde', # S (GMT-01:00) Cape Verde Is.
+    u'Caucasus Standard Time': u'Asia/Yerevan', # D (GMT+04:00) Yerevan / S [XP] (GMT+04:00) Caucasus Standard Time
+    u'Cen. Australia Standard Time': u'Australia/Adelaide', # D (GMT+09:30) Adelaide
+    u'Central America Standard Time': u'America/Guatemala', # S (GMT-06:00) Central America
+    u'Central Asia Standard Time': u'Asia/Almaty', # S (GMT+06:00) Astana
+    u'Central Brazilian Standard Time': u'America/Campo_Grande', # D (GMT-04:00) Manaus
+    u'Central Europe Standard Time': u'Europe/Budapest', # D (GMT+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague
+    u'Central European Standard Time': u'Europe/Warsaw', # D (GMT+01:00) Sarajevo, Skopje, Warsaw, Zagreb
+    u'Central Pacific Standard Time': u'Pacific/Guadalcanal', # S (GMT+11:00) Magadan, Solomon Is., New Caledonia
+    u'Central Standard Time': u'America/Chicago', # D (GMT-06:00) Central Time (US & Canada)
+    u'Central Standard Time (Mexico)': u'America/Mexico_City', # D (GMT-06:00) Guadalajara, Mexico City, Monterrey
+    u'China Standard Time': u'Asia/Shanghai', # S (GMT+08:00) Beijing, Chongqing, Hong Kong, Urumqi
+    u'Dateline Standard Time': u'Etc/GMT+12', # S (GMT-12:00) International Date Line West
+    u'E. Africa Standard Time': u'Africa/Nairobi', # S (GMT+03:00) Nairobi
+    u'E. Australia Standard Time': u'Australia/Brisbane', # S (GMT+10:00) Brisbane
+    u'E. Europe Standard Time': u'Europe/Minsk', # D (GMT+02:00) Minsk
+    u'E. South America Standard Time': u'America/Sao_Paulo', # D (GMT-03:00) Brasilia
+    u'Eastern Standard Time': u'America/New_York', # D (GMT-05:00) Eastern Time (US & Canada)
+    u'Egypt Standard Time': u'Africa/Cairo', # D (GMT+02:00) Cairo
+    u'Ekaterinburg Standard Time': u'Asia/Yekaterinburg', # D (GMT+05:00) Ekaterinburg
+    u'FLE Standard Time': u'Europe/Kiev', # D (GMT+02:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius
+    u'Fiji Standard Time': u'Pacific/Fiji', # D (GMT+12:00) Fiji, Marshall Is.
+    u'GMT Standard Time': u'Europe/London', # D (GMT) Greenwich Mean Time : Dublin, Edinburgh, Lisbon, London
+    u'GTB Standard Time': u'Europe/Istanbul', # D (GMT+02:00) Athens, Bucharest, Istanbul
+    u'Georgian Standard Time': u'Etc/GMT-3', # S (GMT+03:00) Tbilisi
+    u'Greenland Standard Time': u'America/Godthab', # D (GMT-03:00) Greenland
+    u'Greenwich Standard Time': u'Atlantic/Reykjavik', # S (GMT) Monrovia, Reykjavik
+    u'Hawaiian Standard Time': u'Pacific/Honolulu', # S (GMT-10:00) Hawaii
+    u'India Standard Time': u'Asia/Calcutta', # S (GMT+05:30) Chennai, Kolkata, Mumbai, New Delhi
+    u'Iran Standard Time': u'Asia/Tehran', # D (GMT+03:30) Tehran
+    u'Israel Standard Time': u'Asia/Jerusalem', # D (GMT+02:00) Jerusalem
+    u'Jordan Standard Time': u'Asia/Amman', # D (GMT+02:00) Amman
+    u'Kamchatka Standard Time': u'Asia/Kamchatka', # D (GMT+12:00) Petropavlovsk-Kamchatsky
+    u'Korea Standard Time': u'Asia/Seoul', # S (GMT+09:00) Seoul
+    u'Mauritius Standard Time': u'Indian/Mauritius', # D (GMT+04:00) Port Louis
+    u'Mexico Standard Time': u'America/Mexico_City', # D [XP] (GMT-06:00) Guadalajara, Mexico City, Monterrey - Old
+    u'Mexico Standard Time 2': u'America/Chihuahua', # D [XP] (GMT-07:00) Chihuahua, La Paz, Mazatlan - Old
+    u'Mid-Atlantic Standard Time': u'Etc/GMT+2', # D (GMT-02:00) Mid-Atlantic
+    u'Middle East Standard Time': u'Asia/Beirut', # D (GMT+02:00) Beirut
+    u'Montevideo Standard Time': u'America/Montevideo', # D (GMT-03:00) Montevideo
+    u'Morocco Standard Time': u'Africa/Casablanca', # D (GMT) Casablanca
+    u'Mountain Standard Time': u'America/Denver', # D (GMT-07:00) Mountain Time (US & Canada)
+    u'Mountain Standard Time (Mexico)': u'America/Chihuahua', # (GMT-07:00) Chihuahua, La Paz, Mazatlan
+    u'Myanmar Standard Time': u'Asia/Rangoon', # S (GMT+06:30) Yangon (Rangoon)
+    u'N. Central Asia Standard Time': u'Asia/Novosibirsk', # D (GMT+06:00) Novosibirsk
+    u'Namibia Standard Time': u'Africa/Windhoek', # D (GMT+02:00) Windhoek
+    u'Nepal Standard Time': u'Asia/Katmandu', # S (GMT+05:45) Kathmandu
+    u'New Zealand Standard Time': u'Pacific/Auckland', # D (GMT+12:00) Auckland, Wellington
+    u'Newfoundland Standard Time': u'America/St_Johns', # D (GMT-03:30) Newfoundland
+    u'North Asia East Standard Time': u'Asia/Irkutsk', # D (GMT+08:00) Irkutsk
+    u'North Asia Standard Time': u'Asia/Krasnoyarsk', # D (GMT+07:00) Krasnoyarsk
+    u'Pacific SA Standard Time': u'America/Santiago', # D (GMT-04:00) Santiago
+    u'Pacific Standard Time': u'America/Los_Angeles', # D (GMT-08:00) Pacific Time (US & Canada)
+    u'Pacific Standard Time (Mexico)': u'America/Tijuana', # D (GMT-08:00) Tijuana, Baja California
+    u'Pakistan Standard Time': u'Asia/Karachi', # D (GMT+05:00) Islamabad, Karachi
+    u'Paraguay Standard Time': u'America/Asuncion', # (GMT-04:00) Asuncion
+    u'Romance Standard Time': u'Europe/Paris', # D (GMT+01:00) Brussels, Copenhagen, Madrid, Paris
+    u'Russian Standard Time': u'Europe/Moscow', # D (GMT+03:00) Moscow, St. Petersburg, Volgograd
+    u'SA Eastern Standard Time': u'America/Cayenne', # S (GMT-03:00) Cayenne
+    u'SA Pacific Standard Time': u'America/Bogota', # S (GMT-05:00) Bogota, Lima, Quito
+    u'SA Western Standard Time': u'America/La_Paz', # S (GMT-04:00) Georgetown, La Paz, San Juan
+    u'SE Asia Standard Time': u'Asia/Bangkok', # S (GMT+07:00) Bangkok, Hanoi, Jakarta
+    u'Samoa Standard Time': u'Pacific/Apia', # S (GMT-11:00) Midway Island, Samoa
+    u'Singapore Standard Time': u'Asia/Singapore', # S (GMT+08:00) Kuala Lumpur, Singapore
+    u'South Africa Standard Time': u'Africa/Johannesburg', # S (GMT+02:00) Harare, Pretoria
+    u'Sri Lanka Standard Time': u'Asia/Colombo', # S (GMT+05:30) Sri Jayawardenepura
+    u'Taipei Standard Time': u'Asia/Taipei', # S (GMT+08:00) Taipei
+    u'Tasmania Standard Time': u'Australia/Hobart', # D (GMT+10:00) Hobart
+    u'Tokyo Standard Time': u'Asia/Tokyo', # S (GMT+09:00) Osaka, Sapporo, Tokyo
+    u'Tonga Standard Time': u'Pacific/Tongatapu', # S (GMT+13:00) Nuku'alofa
+    u'US Eastern Standard Time': u'Etc/GMT+5', # S (GMT-05:00) Indiana (East)
+    u'US Mountain Standard Time': u'America/Phoenix', # S (GMT-07:00) Arizona
+    u'UTC': u'Etc/GMT', # S (GMT) Coordinated Universal Time
+    u'Ulaanbaatar Standard Time': u'Asia/Ulaanbaatar', # (GMT+08:00) Ulaanbaatar
+    u'Venezuela Standard Time': u'America/Caracas', # S (GMT-04:30) Caracas
+    u'Vladivostok Standard Time': u'Asia/Vladivostok', # D (GMT+10:00) Vladivostok
+    u'W. Australia Standard Time': u'Australia/Perth', # D (GMT+08:00) Perth
+    u'W. Central Africa Standard Time': u'Africa/Lagos', # S (GMT+01:00) West Central Africa
+    u'W. Europe Standard Time': u'Europe/Berlin', # D (GMT+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna
+    u'West Asia Standard Time': u'Asia/Tashkent', # S (GMT+05:00) Tashkent
+    u'West Pacific Standard Time': u'Pacific/Port_Moresby', # S (GMT+10:00) Guam, Port Moresby
+    u'Yakutsk Standard Time': u'Asia/Yakutsk', # D (GMT+09:00) Yakutsk
+}


### PR DESCRIPTION
Our company made a fork of datetime_tz back in 2010, when we added support for windows using win32timezone - which is part of pywin32 - if it is installed.

Unfortunately, we did not immediately attempt to get those changes merged in upstream, and so our version has diverged a little since then, with various minor enhancements.

We realise that this does make for a tricky pull request to handle! Sorry about that... Please let me know if there is anything we can do to make it easier to work with!