### PR TITLE
Drop requirement for python-dateutil<2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ A drop in replacement for Python's datetime module which cares deeply about time
 
 if sys.version[:3] < '3.0':
     data['install_requires'].append('pytz >= 2007g')
-    data['install_requires'].append('python-dateutil >= 1.4, < 2.0')
+    data['install_requires'].append('python-dateutil >= 1.4')
 else:
     data['install_requires'].append('pytz >= 2011g')
     data['install_requires'].append('python-dateutil >= 2.0')


### PR DESCRIPTION
python-dateutil 2.0 is out-of-date and we experience conflicts when trying to use python-datetime-tz in our python environments due to the hard requirement for 2.0 or less. I tried dropping this requirement and all tests pass. Please take a look and let me know if this looks problematic.

Thanks!