### PR TITLE
Allowing nightly to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
   - 3.4
   - nightly
 
+matrix:
+ allow_failures:
+   - python: nightly
+
 sudo: false
 
 cache:


### PR DESCRIPTION
From @dave42
> It seems that inspect.getargspec is deprecated since Python 3.0 and removed in Python 3.6, and
> the 'cryptography' library, pulled in from pyopenssl, still uses it in setup.py, which is why Python
> nightly builds are failing. Could you please switch Travis to build with Python 3.5 and not nightly, 
> until the cryptography library sorts this out?