### PR TITLE
Improve windows timezone mapping

### DIFF
--- a/datetime_tz/detect_windows.py
+++ b/datetime_tz/detect_windows.py
@@ -23,6 +23,7 @@ __author__ = "davidm"
 
 import ctypes
 import warnings
+import locale
 
 import pytz
 
@@ -115,7 +116,8 @@ def _detect_timezone_windows():
           win32timezone.TimeZoneInfo._get_indexed_time_zone_keys("Std"))
     win32tz_key_name = win32timezone_to_en.get(win32tz_name, win32tz_name)
 
-  olson_name = win32tz_map.win32timezones.get(win32tz_key_name, None)
+  territory = locale.getdefaultlocale()[0].split("_", 1)[1]
+  olson_name = win32tz_map.win32timezones.get((win32tz_key_name, territory), win32tz_map.win32timezones.get(win32tz_key_name, None))
   if not olson_name:
     return None
   if not isinstance(olson_name, str):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ import sys
 
 data = dict(
     name='python-datetime-tz',
-    version='0.3',
+    version='0.5.1',
     author='Tim Ansell',
     author_email='mithro@mithis.com',
     url='http://github.com/mithro/python-datetime-tz',

--- a/tests.py
+++ b/tests.py
@@ -450,7 +450,7 @@ class TestLocalTimezoneDetection(TestTimeZoneBase):
 
     self.assertTimezoneEqual(
         detect_windows._detect_timezone_windows(),
-        pytz.timezone("Etc/GMT-2"))
+        pytz.timezone("Africa/Johannesburg"))
 
     windll.kernel32 = kernel32_old
     if win32timezone is None:

--- a/tests.py
+++ b/tests.py
@@ -458,7 +458,7 @@ class TestLocalTimezoneDetection(TestTimeZoneBase):
     else:
       self.assertTimezoneEqual(
           detect_windows._detect_timezone_windows(),
-          pytz.timezone("Etc/GMT-2"))
+          pytz.timezone("Africa/Johannesburg"))
 
     class _win32timezone_mock(object):
 

--- a/tests.py
+++ b/tests.py
@@ -403,12 +403,13 @@ class TestLocalTimezoneDetection(TestTimeZoneBase):
       self.assertNotEqual(detect_windows._detect_timezone_windows(), None)
 
     class kernel32_old(object):
+      STANDARD_NAME = "South Africa Standard Time"
 
-      @staticmethod
-      def GetTimeZoneInformation(tzi_byref):
+      @classmethod
+      def GetTimeZoneInformation(cls, tzi_byref):
         tzi = tzi_byref._obj
         tzi.bias = -120
-        tzi.standard_name = "South Africa Standard Time"
+        tzi.standard_name = cls.STANDARD_NAME
         tzi.standard_start = detect_windows.SYSTEMTIME_c()
         tzi.standard_start.year = 0
         tzi.standard_start.month = 0
@@ -473,7 +474,8 @@ class TestLocalTimezoneDetection(TestTimeZoneBase):
     self.assertTimezoneEqual(
         detect_windows._detect_timezone_windows(),
         pytz.timezone("Australia/Sydney"))
-
+    kernel32_old.STANDARD_NAME = "DoesNotExist"
+    self.assertEqual(detect_windows._detect_timezone_windows(), None)
 
 class TestDatetimeTZ(TestTimeZoneBase):
 

--- a/tests.py
+++ b/tests.py
@@ -469,6 +469,7 @@ class TestLocalTimezoneDetection(TestTimeZoneBase):
           return {"South Africa Standard Time": "AUS Eastern Standard Time"}
 
     self.mocked("detect_windows.win32timezone", _win32timezone_mock)
+    detect_windows.win32timezone_to_en = {}
     self.assertTimezoneEqual(
         detect_windows._detect_timezone_windows(),
         pytz.timezone("Australia/Sydney"))


### PR DESCRIPTION
When we changed the generation of win32tz_map to happen at build time, I didn't notice the new format of the downloaded windowsZones.xml.  The format adjustments to use Windows territories to improve matches actually left us with much poorer matches between Olsen and Windows timezones.  This update now picks the best option, not the last option, as the default translation between the two, and can take your locale territory into account to help refine the mapping.