### PR TITLE
Migrate from Genshi to defusedxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module depends on:
 
 For development:
  * PyLint - Needed for checking for link.
- * Genshi - Needed for building windows mapping file.
+ * defusedxml - Needed for building windows mapping file.
 
 [![Build Status](https://travis-ci.org/mithro/python-datetime-tz.png?branch=master)](https://travis-ci.org/mithro/python-datetime-tz)
 [![Coverage Status](https://coveralls.io/repos/mithro/python-datetime-tz/badge.png)](https://coveralls.io/r/mithro/python-datetime-tz)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=41.0",
     "wheel",
-    "Genshi",
+    "defusedxml",
     "python-dateutil>=2.0",
     "pytz >= 2011g",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Genshi
+defusedxml
 python-dateutil
-pytz>=2007g
+pytz>=2011g

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,11 @@ A drop in replacement for Python's datetime module which cares deeply about time
         "Topic :: Software Development :: Internationalization",
     ],
     packages=['datetime_tz'],
-    install_requires=["pytz >= 2011g", "python-dateutil >= 2.0"],
+    install_requires=[
+        "defusedxml",
+        "python-dateutil >= 2.0",
+        "pytz >= 2011g",
+    ],
     py_modules=['datetime_tz','datetime_tz.pytz_abbr'],
     test_suite='tests',
     cmdclass={'sdist': update_sdist, "install": update_install},

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,6 @@ commands = pytest {posargs: --cov=datetime_tz} tests.py
 deps =
   python-dateutil
   pytz{env:PYTZ_VERSION:}
-  genshi
+  defusedxml
   pytest
   pytest-cov


### PR DESCRIPTION
Migrate from Genshi to defusedxml in update_win32tz_map.py:

* Add `defusedxml` to `install_requires`.  Genshi was never listed, although
  it was only a requirement for building sdist.

* Removed support for copying comments from CLDR XML.  This would be
  difficult without a DOM parser, but the source file contains a local DTD
  reference which is banned in defusedxml.

* Switch `create_win32tz_map` to a mostly-functional processing model, by
  `yield`ing earlier, instead of building complete dicts and `yield`ing
  after-the-fact.  This causes output to be no longer sorted alphabetically.

* Move special handling of `territory=001` into `create_win32tz_map`.

Tested that generated content is identical, although the ordering will
differ.

Google-internal bug: 160436149