### PR TITLE
Better support macOS, where `/usr/share/zoneinfo/posix` doesn't exist

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -86,6 +86,10 @@ except NameError:
 
 FMT = "%Y-%m-%d %H:%M:%S %Z%z"
 
+if sys.platform == "darwin":
+  TZDIR_POSIX = "/usr/share/zoneinfo"
+else:
+  TZDIR_POSIX = "/usr/share/zoneinfo/posix"
 
 # Older versions of pytz only have AmbiguousTimeError, while newer versions
 # throw NonExistentTimeError.
@@ -307,7 +311,7 @@ class TestLocalTimezoneDetection(TestTimeZoneBase):
     os_walk = os.walk
     def os_walk_fake(dirname, *args, **kw):
       if dirname in (
-          "/usr/share/zoneinfo/posix",
+          TZDIR_POSIX,
           ):
         return [
             (dirname, ["Etc", "Australia"], []),
@@ -323,13 +327,13 @@ class TestLocalTimezoneDetection(TestTimeZoneBase):
         filename = os.path.join(os.path.dirname(__file__),
                                 localtime_file)
       if filename in (
-          "/usr/share/zoneinfo/posix/Australia/Melbourne",
-          "/usr/share/zoneinfo/posix/Australia/Sydney",
+          os.path.join(TZDIR_POSIX, "Australia/Melbourne"),
+          os.path.join(TZDIR_POSIX, "Australia/Sydney"),
           ):
         filename = test_zonedata_sydney
 
       if filename in (
-          "/usr/share/zoneinfo/posix/Etc/UTC",
+          os.path.join(TZDIR_POSIX, "Etc/UTC"),
           ):
         filename = os.path.join(os.path.dirname(__file__),
                                 "test_zonedata_utc")


### PR DESCRIPTION
In this case, iterate through the files in `/usr/share/zoneinfo`, skipping
unreadable files.

This allows `datetime_tz.datetime_tz.smartparse` to work in most cases.

Currently:
```
❯ python3
Python 3.6.8 (v3.6.8:3c6b436a57, Dec 24 2018, 02:04:31) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime_tz
>>> datetime_tz.datetime_tz.smartparse('Feb 22 00:30:04')
/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/datetime_tz/__init__.py:335: UserWarning: We detected no matches for your /etc/localtime.
  warnings.warn("We detected no matches for your /etc/localtime.")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/datetime_tz/__init__.py", line 606, in smartparse
    default = dt.replace(hour=0, minute=0, second=0, microsecond=0)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/datetime_tz/__init__.py", line 564, in replace
    replaced, tzinfo=tzinfo or self.tzinfo.zone, is_dst=is_dst)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/datetime_tz/__init__.py", line 425, in __new__
    tzinfo = _tzinfome(kw.pop("tzinfo"))
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/datetime_tz/__init__.py", line 100, in _tzinfome
    assert tzinfo.zone in pytz.all_timezones
AssertionError
```
With this commit:
```
❯ python3
Python 3.6.8 (v3.6.8:3c6b436a57, Dec 24 2018, 02:04:31) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime_tz
>>> datetime_tz.datetime_tz.smartparse('Feb 22 00:30:04')
/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/datetime_tz/__init__.py:326: UserWarning: Skipping posixrules because not in pytz database.
  warnings.warn("Skipping %s because not in pytz database." % tzname)
/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/datetime_tz/__init__.py:338: UserWarning: We detected multiple matches for your /etc/localtime. (Matches where [<DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>, <DstTzInfo 'US/Eastern' LMT-1 day, 19:04:00 STD>])
  "(Matches where %s)" % matches)
datetime_tz(2021, 2, 22, 0, 30, 4, tzinfo=<DstTzInfo 'America/New_York' EST-1 day, 19:00:00 STD>)
>>>
```
