### PR TITLE
Fix potential non-determinism in generated map.

### DIFF
--- a/datetime_tz/update_win32tz_map.py
+++ b/datetime_tz/update_win32tz_map.py
@@ -99,7 +99,7 @@ def update_stored_win32tz_map():
       "Generated automatically by {1}'''\n"
       "source_hash = {2!r}  # md5 sum of xml source data\n"
       "win32timezones = {{\n"
-    ).format(_CLDR_WINZONES_URL, __file__, source_hash))
+    ).format(_CLDR_WINZONES_URL, os.path.basename(__file__), source_hash))
 
   for z in map_zones:
     map_file.write("  %r: %r,\n" % z)


### PR DESCRIPTION
A build system which non-determinism in the path of the executable used to build the file will result in non-determinism in the final file.

This is resolved by only using the filename portion of the file.