### PR TITLE
fix pytz dependency for python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 defusedxml
 python-dateutil
-pytz>=2011g
+pytz>=2023.3


### PR DESCRIPTION
    pytz versioning has changed from 2011<a,b,c,d> to 2023.<1,2,3>
    the other versioning uses UserDict from collections which is moved out for 3.11

    so any apps that run on 3.11 requiring python-datetime-tz will not work unless this dependency is fixed.